### PR TITLE
[WIP] Add cuesheet support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ popstation_md: popstation_md.o common.o
 	$(LINK.c) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 popstation: popstation.o common.o
-	$(LINK.c) $(LDFLAGS) -o $@ $^ $(LIBS) -liniparser
+	$(LINK.c) $(LDFLAGS) -o $@ $^ $(LIBS) -liniparser -lcue
 
 clean:
 	rm -f popstation_md popstation *.o

--- a/popstation.c
+++ b/popstation.c
@@ -109,7 +109,6 @@ void *create_toc_cue(char *iso_name, int *size) {
     printf("No CUE file found. Assuming this is a pure-ISO9660 image!\n");
     return NULL;
   }
-  fclose(cue_file);
 
   printf("Making TOC from CUE file \"%s\"...\n", cue_name);
 
@@ -224,6 +223,7 @@ void *create_toc_cue(char *iso_name, int *size) {
   }
 
   cd_delete(cue_data);
+  fclose(cue_file);
   return entries;
 }
 

--- a/popstation.c
+++ b/popstation.c
@@ -116,7 +116,7 @@ void *create_toc_cue(char *iso_name, int *size) {
 
   count = cd_get_ntrack(cue_data);
 
-  if (count > 1) {
+  if (count < 1) {
     printf("Failed to get TOC count from CUE, are you sure it's a valid CUE "
            "file?\n");
 

--- a/popstation.c
+++ b/popstation.c
@@ -133,13 +133,13 @@ void *create_toc_cue(char *iso_name, int *size) {
   track_data = cd_get_track(cue_data, 1);
   entries[0].control = cue_get_control(track_data);
   entries[0].adr = 0x01;
-  entries[0].tno = 0x48;
+  entries[0].tno = 0x00;
   entries[0].point = 0xa0;
   // MIN/SEC/FRAME are running time of the lead-in, probably 0.
-  entries[0].amin   = bcd(0x48);
-  entries[0].asec   = bcd(0x48);
-  entries[0].aframe = bcd(0x48);
-  entries[0].zero = 0x48;
+  entries[0].amin   = bcd(0x00);
+  entries[0].asec   = bcd(0x00);
+  entries[0].aframe = bcd(0x00);
+  entries[0].zero = 0x00;
   // Defines the first track of the program area
   entries[0].pmin = 0x01;
   // Defines the program area format
@@ -158,11 +158,11 @@ void *create_toc_cue(char *iso_name, int *size) {
   track_data = cd_get_track(cue_data, count);
   entries[1].control = cue_get_control(track_data);
   entries[1].adr = 0x01;
-  entries[1].tno = 0x48;
+  entries[1].tno = 0x00;
   entries[1].point = 0xa1;
-  entries[1].amin   = bcd(0x48);
-  entries[1].asec   = bcd(0x48);
-  entries[1].aframe = bcd(0x48);
+  entries[1].amin   = bcd(0x00);
+  entries[1].asec   = bcd(0x00);
+  entries[1].aframe = bcd(0x00);
   // Defines the last track of the program area
   entries[1].pmin   = bcd(count);
   // Always zero.
@@ -173,11 +173,11 @@ void *create_toc_cue(char *iso_name, int *size) {
   track_data = cd_get_track(cue_data, 1);
   entries[2].control = cue_get_control(track_data);
   entries[2].adr = 0x01;
-  entries[2].tno = 0x48;
+  entries[2].tno = 0x00;
   entries[2].point = 0xa2;
-  entries[2].amin   = bcd(0x48);
-  entries[2].asec   = bcd(0x48);
-  entries[2].aframe = bcd(0x48);
+  entries[2].amin   = bcd(0x00);
+  entries[2].asec   = bcd(0x00);
+  entries[2].aframe = bcd(0x00);
   // Start time of the leadout area
   index = track_get_start(track_data) + track_get_length(track_data);
   entries[2].pmin   = bcd(index_get_min(index));
@@ -202,18 +202,18 @@ void *create_toc_cue(char *iso_name, int *size) {
     // Probably the index number, not actually the TNO / track number;
     // the standard theoretically allows 99 indices per track,
     // but most tracks have only one.
-    entries[entry].tno = 0x48; // "0"
+    entries[entry].tno = 0x00;
     // From here on out, POINT is the track number.
     entries[entry].point = i;
 
     // MIN/SEC/FRAME are running time of the lead-in, probably 0.
     // These hold true regardless of POINT.
-    entries[entry].amin   = bcd(0x48);
-    entries[entry].asec   = bcd(0x48);
-    entries[entry].aframe = bcd(0x48);
+    entries[entry].amin   = bcd(0x00);
+    entries[entry].asec   = bcd(0x00);
+    entries[entry].aframe = bcd(0x00);
 
     // What's on the tin. If this is non-zero, it's not standards compliant.
-    entries[entry].zero = 0x48;
+    entries[entry].zero = 0x00;
 
     // Start time of the track
     index = track_get_index(track_data, 1);

--- a/popstation.c
+++ b/popstation.c
@@ -169,7 +169,7 @@ void *create_toc_cue(char *iso_name, int *size) {
   entries[1].pframe = bcd(0x00);
 
   // Next Q subchannel contains data about the lead-out area.
-  track_data = cd_get_track(cue_data, 1);
+  track_data = cd_get_track(cue_data, count);
   entries[2].control = cue_get_control(track_data);
   entries[2].adr = 0x01;
   entries[2].tno = 0x00;

--- a/popstation.c
+++ b/popstation.c
@@ -163,6 +163,7 @@ void *create_toc_cue(char *iso_name, int *size) {
   entries[1].amin   = bcd(0x00);
   entries[1].asec   = bcd(0x00);
   entries[1].aframe = bcd(0x00);
+  entries[1].zero = 0x00;
   // Defines the last track of the program area
   entries[1].pmin   = bcd(count);
   // Always zero.
@@ -178,6 +179,7 @@ void *create_toc_cue(char *iso_name, int *size) {
   entries[2].amin   = bcd(0x00);
   entries[2].asec   = bcd(0x00);
   entries[2].aframe = bcd(0x00);
+  entries[2].zero = 0x00;
   // Start time of the leadout area
   index = track_get_start(track_data) + track_get_length(track_data);
   entries[2].pmin   = bcd(index_get_min(index));

--- a/popstation.c
+++ b/popstation.c
@@ -107,7 +107,7 @@ void *create_toc_cue(char *iso_name, int *size) {
 
   cue_file = fopen(cue_name, "rb");
   if (!cue_file) {
-    printf("No CCD file found. Assuming this is a pure-ISO9660 image!\n");
+    printf("No CUE file found. Assuming this is a pure-ISO9660 image!\n");
     return NULL;
   }
   fclose(cue_file);
@@ -119,7 +119,7 @@ void *create_toc_cue(char *iso_name, int *size) {
   count = cd_get_ntrack(cue_data);
 
   if (count > 1) {
-    printf("Failed to get TOC count from CCD, are you sure it's a valid CCD "
+    printf("Failed to get TOC count from CUE, are you sure it's a valid CUE "
            "file?\n");
 
     return NULL;

--- a/popstation.c
+++ b/popstation.c
@@ -418,8 +418,10 @@ void convert(char *input, char *output, char *title, char *code,
     toc_size = getsize(t);
     toc = 1;
     fclose(t);
-  } else if ((tocptr = create_toc_ccd(input, &toc_size)) != NULL) {
+  } else if ((tocptr = create_toc_cue(input, &toc_size)) != NULL) {
     toc = 2;
+  } else if ((tocptr = create_toc_ccd(input, &toc_size)) != NULL) {
+    toc = 3;
   } else {
     toc = 0;
   }
@@ -583,7 +585,7 @@ void convert(char *input, char *output, char *title, char *code,
       fread(buffer, 1, toc_size, t);
       memcpy(data1 + 1024, buffer, toc_size);
       fclose(t);
-    } else if (toc == 2) {
+    } else if (toc == 2 || toc == 3) {
       memcpy(data1 + 1024, tocptr, toc_size);
       free(tocptr);
     }

--- a/popstation.c
+++ b/popstation.c
@@ -98,7 +98,6 @@ void *create_toc_cue(char *iso_name, int *size) {
   Track *track_data;
   tocentry *entries;
   int count, i, index, entry;
-  char tno;
 
   strcpy(cue_name, iso_name);
   cue_name[iso_name_length - 3] = 'c';


### PR DESCRIPTION
This WIP branch adds support for using cuesheets instead of CCD files for TOC data. It's mostly finished, and generates valid PBP files, but CDDA wasn't working in the one game I tried (Transport Tycoon). That said, the same is true for CCD files.

The generated TOC is almost identical to the one using CCD as a base. The primary differences are:
* pregaps - the `MIN/SEC/FRAME` values are set according to the pregap in the cuesheet, while the CCD has zero-length cuesheets listed for every track.
* leadout position - the CCD-generated TOC has a later leadout position, while the value inferred in the cuesheet is at the end of the last track. The latter may very well be wrong, and it's possible I should be looking at the size of the BIN file to determine the actual leadout position - need to investigate more.

A few notes:

* The `libcue` library is required for CUE parsing. It's available in Homebrew.
* CUE files are currently preferred over CCD files.
* If there's both a CUE file and a CCD file, and CUE parsing fails, it will fall back to the CCD file.

TODOs:

- [ ] Investigate leadout position detection
- [ ] Make sure pregaps and track start positions are always specified correctly
- [ ] Make sure single-track cuesheets and unusual layout cuesheets are handled properly